### PR TITLE
Handle base64-encoded request bodies

### DIFF
--- a/Sources/Vercel/InvokeEvent.swift
+++ b/Sources/Vercel/InvokeEvent.swift
@@ -13,6 +13,7 @@ public struct InvokeEvent: Codable, Sendable {
         public let headers: HTTPHeaders
         public let path: String
         public let body: String?
+        public let encoding: String?
     }
 
     public let body: String

--- a/Tests/VercelTests/RequestTests.swift
+++ b/Tests/VercelTests/RequestTests.swift
@@ -46,4 +46,35 @@ final class RequestTests: XCTestCase {
         XCTAssertEqual(req.method, .GET)
         XCTAssertEqual(req.searchParams["token"], "12345")
     }
+
+    func testPlainBody() throws {
+        let json = """
+        {
+          "method": "PUT",
+          "path": "/",
+          "headers": {},
+          "body": "hello"
+        }
+        """
+        let payload = try JSONDecoder().decode(InvokeEvent.Payload.self, from: json.data(using: .utf8)!)
+        let req = Request(payload)
+        XCTAssertEqual(req.body, "hello")
+    }
+
+    func testBase64Body() throws {
+        let json = """
+        {
+          "method": "PUT",
+          "path": "/",
+          "headers": {},
+          "body": "/////w==",
+          "encoding": "base64"
+        }
+        """
+        let payload = try JSONDecoder().decode(InvokeEvent.Payload.self, from: json.data(using: .utf8)!)
+        let req = Request(payload)
+        let expectData: [UInt8] = [0xff, 0xff, 0xff, 0xff]
+        XCTAssertEqual(req.rawBody, Data(expectData))
+        XCTAssertNil(req.body)
+    }
 }


### PR DESCRIPTION
Hi, 

This PR adds support for the case where vercel sends base64-encoded request bodies (indicated by `"encoding": "base64"` in the payload). This doesn't seem to actually be documented so I'm following the behaviour of the official python runtime for this: https://github.com/vercel/vercel/blob/main/packages/python/vc_init.py#L54 .
The decoded request body is then exposed as `Data` in `Request.rawBody`, and `Request.body` is now a shortcut for utf-8 decoding the rawBody.