### PR TITLE
Include Node version note in Readme (Deployment section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ swift package --disable-sandbox vercel deploy
 
 ### Deploy Options
 
+> [!IMPORTANT]  
+> Before deploying your project, make sure that the selected **Node version is 18.x** instead of 20.x. 
+> You can find it in your project Settings, in the General tab.
+> Using 20.x will result in a [_Serverless Function contains invalid runtime error_](https://vercel.com/guides/serverless-function-contains-invalid-runtime-error)
+
 ```bash
 swift package --disable-sandbox vercel deploy
 ```


### PR DESCRIPTION
When deploying a project using this starter kit, I got the following error:

> Error: The following Serverless Functions contain an invalid "runtime":
> App (provided.al2)

I found in this [support page](https://vercel.com/guides/serverless-function-contains-invalid-runtime-error) that the Node 20.x version results in an error. Downgrading Node to 18.x fixed it.

I added this instruction in the deployment section of the Readme.