### PR TITLE
Update runtime to al2023

### DIFF
--- a/Plugins/VercelPackager/VercelOutput.swift
+++ b/Plugins/VercelPackager/VercelOutput.swift
@@ -424,7 +424,7 @@ extension VercelOutput {
 extension VercelOutput {
 
     public struct FunctionConfiguration: Codable {
-        public var runtime: String = "provided.al2"
+        public var runtime: String = "provided.al2023"
         public var handler: String = "bootstrap"
         public var architecture: Architecture? = nil
         public var memory: Int? = nil


### PR DESCRIPTION
Deploying to Vercel when the Node version is set to al2 fails.

One fix is to downgrade Node to 18.x, but updating the runtime to `provided.al2023` is a better approach.